### PR TITLE
QNXOSG-495: Resolve gtk build failure

### DIFF
--- a/subprojects/cairo.wrap
+++ b/subprojects/cairo.wrap
@@ -1,8 +1,8 @@
 [wrap-git]
 directory = cairo
-url = https://gitlab.freedesktop.org/cairo/cairo.git
-push-url = ssh://git@gitlab.freedesktop.org:cairo/cairo.git
-revision = 1.17.6
+url = https://github.com/qnx-ports/cairo.git
+push-url = ssh://git@github.com:qnx-ports/cairo.git
+revision = master
 depth = 1
 diff_files = qnx/cairo/0001-Modifications-for-QNX.patch
 

--- a/subprojects/fribidi.wrap
+++ b/subprojects/fribidi.wrap
@@ -9,4 +9,3 @@ diff_files = qnx/fribidi/0001-Modifications-for-QNX.patch
 
 [provide]
 dependency_names = fribidi
-

--- a/subprojects/fribidi.wrap
+++ b/subprojects/fribidi.wrap
@@ -2,9 +2,11 @@
 directory = fribidi
 url = https://github.com/fribidi/fribidi.git
 push-url = git@github.com:fribidi/fribidi.git
-revision = master
+# lock at release version 1.0.16
+revision = 1.0.16
 depth = 1
 diff_files = qnx/fribidi/0001-Modifications-for-QNX.patch
 
 [provide]
 dependency_names = fribidi
+

--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -2,8 +2,10 @@
 directory = gi-docgen
 url = https://gitlab.gnome.org/GNOME/gi-docgen.git
 push-url = ssh://git@ssh.gitlab.gnome.org:GNOME/gi-docgen.git
-revision = main
+# lock at release version 2024.1
+revision = 2024.1
 depth = 1
 
 [provide]
 program_names = gi-docgen
+

--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -8,4 +8,3 @@ depth = 1
 
 [provide]
 program_names = gi-docgen
-

--- a/subprojects/libsass.wrap
+++ b/subprojects/libsass.wrap
@@ -4,4 +4,3 @@ directory=libsass
 url=https://github.com/lazka/libsass.git
 revision=meson
 depth=1
-

--- a/subprojects/libsass.wrap
+++ b/subprojects/libsass.wrap
@@ -1,5 +1,7 @@
 [wrap-git]
 directory=libsass
+# this repo has been archived since Oct 2nd, 2023
 url=https://github.com/lazka/libsass.git
 revision=meson
 depth=1
+

--- a/subprojects/pango.wrap
+++ b/subprojects/pango.wrap
@@ -2,8 +2,8 @@
 directory = pango
 url = https://gitlab.gnome.org/GNOME/pango.git
 push-url = ssh://git@ssh.gitlab.gnome.org:GNOME/pango.git
-# needs to be main, because we build the nightly docs from the subproject
-revision = main
+# pick the commit at version 1.54
+revision = 5b1551e933d069d15169eb7c8bd6b2e95cbfe230
 depth = 1
 diff_files = qnx/pango/0001-Modifications-for-QNX.patch
 

--- a/subprojects/pango.wrap
+++ b/subprojects/pango.wrap
@@ -2,8 +2,8 @@
 directory = pango
 url = https://gitlab.gnome.org/GNOME/pango.git
 push-url = ssh://git@ssh.gitlab.gnome.org:GNOME/pango.git
-# pick the commit at version 1.54
-revision = 5b1551e933d069d15169eb7c8bd6b2e95cbfe230
+# lock at tag 1.54.0
+revision = 1.54.0
 depth = 1
 diff_files = qnx/pango/0001-Modifications-for-QNX.patch
 
@@ -13,3 +13,4 @@ pangoft2 = libpangoft2_dep
 pangoxft = libpangoxft_dep
 pangowin32 = libpangowin32_dep
 pangocairo = libpangocairo_dep
+

--- a/subprojects/sassc.wrap
+++ b/subprojects/sassc.wrap
@@ -1,5 +1,6 @@
 [wrap-git]
 directory = sassc
+# this repo has been archived since Oct 2nd, 2023
 url = https://github.com/lazka/sassc.git
 revision = meson
 depth = 1

--- a/subprojects/sysprof.wrap
+++ b/subprojects/sysprof.wrap
@@ -7,4 +7,3 @@ depth = 1
 
 [provide]
 dependency_names = sysprof-4, sysprof-capture-4, sysprof-ui-4
-

--- a/subprojects/sysprof.wrap
+++ b/subprojects/sysprof.wrap
@@ -1,8 +1,10 @@
 [wrap-git]
 directory = sysprof
 url = https://gitlab.gnome.org/GNOME/sysprof.git
-revision = master
+# lock at release 47.2
+revision = 47.2
 depth = 1
 
 [provide]
 dependency_names = sysprof-4, sysprof-capture-4, sysprof-ui-4
+


### PR DESCRIPTION
GTK was failing to build as subprojects `pango` and `cairo` recently upgraded versions of their dependencies. This commit locks `pango` at v1.54 and picks `cairo` from qnx-ports instead.