### PR TITLE
Install all icons of hicolor theme

### DIFF
--- a/demos/gtk-demo/meson.build
+++ b/demos/gtk-demo/meson.build
@@ -261,8 +261,8 @@ executable('gtk4-demo-application',
 # icons
 icontheme_dir = join_paths(gtk_datadir, 'icons/hicolor')
 
-foreach size: ['scalable', 'symbolic']
-  install_subdir('data/' + size, install_dir: icontheme_dir)
+foreach size: ['16x16', '32x32', '64x64', 'scalable', 'symbolic']
+  install_subdir('../../gtk/icons/' + size, install_dir: icontheme_dir)
 endforeach
 
 # desktop file


### PR DESCRIPTION
The complete `hicolor` icons pack is at `gtk/gtk/icons/`. This change installs all the icons of the default theme from this path to `INSTALL_ROOT_nto`'s `/share` folder. 

*Testing*:
`gtk4-demo`'s `Transformation` feature should now display all icons.